### PR TITLE
Fix Databricks cache key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -914,8 +914,8 @@ async function fetchDataDatabricks(searchParam: string): Promise<ListingResult[]
 		const response = await fetch("https://marketplace.databricks.com/api/2.0/public-marketplace-listings", {
 			cf: {
 				cacheTtlByStatus: { "200-299": 1209600, 404: 1, "500-599": 0 }, // 2 weeks in seconds
-				cacheEverything: true,
-				cacheKey: `databricks`
+                                cacheEverything: true,
+                                cacheKey: `databricks-${searchParam}`
 			}
 		});
 

--- a/test/databricks.test.ts
+++ b/test/databricks.test.ts
@@ -1,0 +1,43 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, beforeEach, expect, vi, Mock } from 'vitest';
+import worker from '../src/index';
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+describe('Databricks Integration', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it('uses search-specific cache key for Databricks requests', async () => {
+    const searchTerm = 'example';
+    const databricksResponse = { listings: [] };
+    (global.fetch as Mock).mockImplementation((url: string) => {
+      if (url.includes('marketplace.databricks.com')) {
+        return Promise.resolve({
+          ok: true,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: () => Promise.resolve(databricksResponse)
+        } as Response);
+      }
+      return Promise.reject(new Error('skip'));
+    });
+
+    const request = new IncomingRequest(`http://example.com?search=${encodeURIComponent(searchTerm)}`);
+    const ctx = createExecutionContext();
+    await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://marketplace.databricks.com/api/2.0/public-marketplace-listings',
+      expect.objectContaining({
+        cf: {
+          cacheTtlByStatus: { '200-299': 1209600, 404: 1, '500-599': 0 },
+          cacheEverything: true,
+          cacheKey: `databricks-${searchTerm}`
+        }
+      })
+    );
+  });
+});

--- a/test/databricks.test.ts
+++ b/test/databricks.test.ts
@@ -14,7 +14,7 @@ describe('Databricks Integration', () => {
     const searchTerm = 'example';
     const databricksResponse = { listings: [] };
     (global.fetch as Mock).mockImplementation((url: string) => {
-      if (url.includes('marketplace.databricks.com')) {
+      if (new URL(url).hostname === 'marketplace.databricks.com') {
         return Promise.resolve({
           ok: true,
           headers: new Headers({ 'content-type': 'application/json' }),


### PR DESCRIPTION
## Summary
- ensure databricks queries have unique cache keys
- add test for databricks cache key

## Testing
- `npx vitest` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684021cbd3cc832a9455953167faf424