### PR TITLE
Update Databricks cache key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -911,11 +911,12 @@ async function fetchDataDatabricks(searchParam: string): Promise<ListingResult[]
 	}
 
 	try {
+                const cacheKey = `databricks-${searchParam}`;
                 const response = await fetch("https://marketplace.databricks.com/api/2.0/public-marketplace-listings", {
                         cf: {
                                 cacheTtlByStatus: { "200-299": 1209600, 404: 1, "500-599": 0 }, // 2 weeks in seconds
                                 cacheEverything: true,
-                                cacheKey: `databricks-${searchParam}`
+                                cacheKey
                         }
                 });
 

--- a/test/databricks.test.ts
+++ b/test/databricks.test.ts
@@ -63,6 +63,28 @@ describe('Databricks Integration', () => {
     });
   });
 
+  it('uses a distinct cacheKey for each search term', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({ listings: [] })
+    } as Response);
+
+    await fetchDataDatabricks('alpha');
+    await fetchDataDatabricks('beta');
+
+    expect(vi.mocked(fetch).mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        cf: expect.objectContaining({ cacheKey: 'databricks-alpha' })
+      })
+    );
+    expect(vi.mocked(fetch).mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        cf: expect.objectContaining({ cacheKey: 'databricks-beta' })
+      })
+    );
+  });
+
   it('handles API errors gracefully', async () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error('API Error'));
     await expect(fetchDataDatabricks('test')).resolves.toEqual([]);


### PR DESCRIPTION
## Summary
- key results from databricks by search term
- test cacheKey is unique per query

## Testing
- `npm test` *(fails: vitest snapshot environment module missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840c738fac0832ab278a0da900e139a